### PR TITLE
🔐 [Security] Encrypt Stellar private keys in database

### DIFF
--- a/STELLAR_KEY_MANAGEMENT.md
+++ b/STELLAR_KEY_MANAGEMENT.md
@@ -1,0 +1,136 @@
+# Stellar Seed Key Management & Rotation Guide
+
+## Overview
+
+Stellar secret seeds are encrypted at rest using Fernet symmetric encryption
+(`cryptography` library). The encryption key is stored in the environment
+variable `STELLAR_SEED_ENCRYPTION_KEY`, never in the codebase.
+
+---
+
+## Initial Setup
+
+### 1. Generate an encryption key
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+### 2. Add to your `.env` file
+
+```
+STELLAR_SEED_ENCRYPTION_KEY=<your-generated-key>
+```
+
+### 3. Run migrations
+
+```bash
+python manage.py migrate attendance 0003_encrypt_stellar_seed
+```
+
+This will encrypt any existing plaintext seeds in the database automatically.
+
+---
+
+## Key Rotation
+
+Key rotation means replacing the current encryption key with a new one and
+re-encrypting all seeds with the new key.
+
+### When to rotate
+
+- Suspected key compromise
+- Staff with key access leaves the team
+- Periodic rotation policy (recommended: every 90 days in production)
+
+### Steps
+
+#### 1. Generate a new key
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+#### 2. Back up your database
+
+```bash
+# SQLite
+cp db.sqlite3 db.sqlite3.backup_$(date +%Y%m%d)
+```
+
+#### 3. Run the rotation management command
+
+```bash
+python manage.py rotate_stellar_seed_key \
+    --old-key <current-STELLAR_SEED_ENCRYPTION_KEY> \
+    --new-key <newly-generated-key>
+```
+
+This command (see `attendance/management/commands/rotate_stellar_seed_key.py`):
+- Decrypts every seed with the old key
+- Re-encrypts it with the new key
+- Saves atomically — no window where seeds are plaintext
+
+#### 4. Update your environment
+
+Replace `STELLAR_SEED_ENCRYPTION_KEY` in your `.env` / secrets manager with the new key.
+
+#### 5. Restart the application
+
+The new key takes effect on next startup.
+
+---
+
+## Management Command
+
+Create `attendance/management/commands/rotate_stellar_seed_key.py`:
+
+```python
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from cryptography.fernet import Fernet
+from attendance.models import User
+
+
+class Command(BaseCommand):
+    help = 'Rotate the Stellar seed encryption key.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--old-key', required=True)
+        parser.add_argument('--new-key', required=True)
+
+    def handle(self, *args, **options):
+        old_fernet = Fernet(options['old_key'].encode())
+        new_fernet = Fernet(options['new_key'].encode())
+
+        users = User.objects.exclude(_stellar_seed__isnull=True).exclude(_stellar_seed='')
+        rotated = 0
+
+        with transaction.atomic():
+            for user in users:
+                raw = user._stellar_seed
+                if not raw:
+                    continue
+                # Decrypt with old key
+                if raw.startswith('enc:'):
+                    plaintext = old_fernet.decrypt(raw[4:].encode()).decode()
+                else:
+                    plaintext = raw  # legacy plaintext
+                # Re-encrypt with new key
+                user._stellar_seed = 'enc:' + new_fernet.encrypt(plaintext.encode()).decode()
+                user.save(update_fields=['_stellar_seed'])
+                rotated += 1
+
+        self.stdout.write(self.style.SUCCESS(f'Rotated {rotated} seeds successfully.'))
+```
+
+---
+
+## Security Notes
+
+- The `STELLAR_SEED_ENCRYPTION_KEY` must **never** be committed to version control.
+- Ensure `.env` is listed in `.gitignore`.
+- In production, store the key in a secrets manager (AWS Secrets Manager, HashiCorp Vault,
+  GCP Secret Manager) rather than a plain `.env` file.
+- The `enc:` prefix on stored values allows the code to distinguish encrypted values from
+  any legacy plaintext values, making the migration safe to run more than once (idempotent).

--- a/attendance/encryption.py
+++ b/attendance/encryption.py
@@ -1,0 +1,75 @@
+"""
+Encryption utility for sensitive fields (stellar_seed).
+
+Uses Fernet symmetric encryption from the cryptography library.
+The encryption key must be set via the STELLAR_SEED_ENCRYPTION_KEY
+environment variable.
+
+Generating a key (run once, store in .env):
+    python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+"""
+
+from cryptography.fernet import Fernet, InvalidToken
+from django.conf import settings
+
+
+def get_fernet():
+    """
+    Return a Fernet instance using the encryption key from settings.
+    Raises ImproperlyConfigured if key is missing or invalid.
+    """
+    key = getattr(settings, 'STELLAR_SEED_ENCRYPTION_KEY', None)
+    if not key:
+        from django.core.exceptions import ImproperlyConfigured
+        raise ImproperlyConfigured(
+            "STELLAR_SEED_ENCRYPTION_KEY must be set in environment variables."
+        )
+    return Fernet(key.encode() if isinstance(key, str) else key)
+
+
+def encrypt_seed(plaintext_seed: str) -> str:
+    """
+    Encrypt a Stellar secret seed.
+
+    Args:
+        plaintext_seed: The raw Stellar secret seed string.
+
+    Returns:
+        Encrypted seed as a UTF-8 string (prefixed with 'enc:' to distinguish
+        encrypted values from any legacy plaintext values in the database).
+    """
+    if not plaintext_seed:
+        return plaintext_seed
+    # Already encrypted — do not double-encrypt
+    if plaintext_seed.startswith('enc:'):
+        return plaintext_seed
+    fernet = get_fernet()
+    encrypted = fernet.encrypt(plaintext_seed.encode())
+    return 'enc:' + encrypted.decode()
+
+
+def decrypt_seed(stored_value: str) -> str:
+    """
+    Decrypt a stored Stellar secret seed.
+
+    Args:
+        stored_value: The value stored in the database (may be encrypted or
+                      legacy plaintext).
+
+    Returns:
+        The original plaintext seed string.
+    """
+    if not stored_value:
+        return stored_value
+    # Legacy plaintext value — return as-is (will be encrypted on next save)
+    if not stored_value.startswith('enc:'):
+        return stored_value
+    fernet = get_fernet()
+    try:
+        decrypted = fernet.decrypt(stored_value[4:].encode())
+        return decrypted.decode()
+    except InvalidToken:
+        raise ValueError(
+            "Failed to decrypt stellar_seed. The STELLAR_SEED_ENCRYPTION_KEY "
+            "may be incorrect or the value may be corrupted."
+        )

--- a/attendance/migrations/0003_encrypt_stellar_seed.py
+++ b/attendance/migrations/0003_encrypt_stellar_seed.py
@@ -1,0 +1,87 @@
+"""
+Migration: Encrypt existing plaintext stellar_seed values.
+
+This migration:
+1. Widens the stellar_seed column from max_length=56 to max_length=200
+   to accommodate the Fernet-encrypted ciphertext + 'enc:' prefix.
+2. Encrypts all existing plaintext seeds in the database.
+
+BEFORE running this migration:
+- Ensure STELLAR_SEED_ENCRYPTION_KEY is set in your environment / .env file.
+- Back up your database.
+
+Generate a key if you haven't already:
+    python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+
+Then add to .env:
+    STELLAR_SEED_ENCRYPTION_KEY=<your-generated-key>
+"""
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def encrypt_existing_seeds(apps, schema_editor):
+    """
+    Encrypt any plaintext seeds already stored in the database.
+    Seeds that already start with 'enc:' are skipped (idempotent).
+    """
+    # Import here so the encryption utility uses the current Django settings.
+    from attendance.encryption import encrypt_seed
+
+    User = apps.get_model('attendance', 'User')
+    users_to_update = []
+
+    for user in User.objects.exclude(stellar_seed__isnull=True).exclude(stellar_seed=''):
+        if not user.stellar_seed.startswith('enc:'):
+            user.stellar_seed = encrypt_seed(user.stellar_seed)
+            users_to_update.append(user)
+
+    if users_to_update:
+        User.objects.bulk_update(users_to_update, ['stellar_seed'])
+
+
+def decrypt_existing_seeds(apps, schema_editor):
+    """
+    Reverse operation: decrypt seeds back to plaintext.
+    Used only if rolling back this migration.
+    WARNING: This re-exposes plaintext seeds in the database.
+    """
+    from attendance.encryption import decrypt_seed
+
+    User = apps.get_model('attendance', 'User')
+    users_to_update = []
+
+    for user in User.objects.exclude(stellar_seed__isnull=True).exclude(stellar_seed=''):
+        if user.stellar_seed.startswith('enc:'):
+            user.stellar_seed = decrypt_seed(user.stellar_seed)
+            users_to_update.append(user)
+
+    if users_to_update:
+        User.objects.bulk_update(users_to_update, ['stellar_seed'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('attendance', '0002_attendancesession_blockchain_verified_and_more'),
+    ]
+
+    operations = [
+        # Step 1: Widen the column to hold encrypted values
+        migrations.AlterField(
+            model_name='user',
+            name='stellar_seed',
+            field=models.CharField(
+                blank=True,
+                null=True,
+                max_length=200,
+                help_text='Fernet-encrypted Stellar secret seed. Never store plaintext.',
+            ),
+        ),
+        # Step 2: Encrypt all existing plaintext seeds
+        migrations.RunPython(
+            encrypt_existing_seeds,
+            reverse_code=decrypt_existing_seeds,
+        ),
+    ]

--- a/attendance/models.py
+++ b/attendance/models.py
@@ -1,13 +1,37 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from django.utils import timezone
+from .encryption import encrypt_seed, decrypt_seed
+
 
 class User(AbstractUser):
     is_admin = models.BooleanField(default=False)
     is_teacher = models.BooleanField(default=False)
     is_student = models.BooleanField(default=False)
     stellar_public_key = models.CharField(max_length=56, blank=True, null=True)
-    stellar_seed = models.CharField(max_length=56, blank=True, null=True)  # This should be encrypted in production
+    # Stores Fernet-encrypted seed. Max length increased to accommodate encryption overhead.
+    # Raw Stellar seeds are 56 chars; encrypted + 'enc:' prefix is ~120 chars.
+    _stellar_seed = models.CharField(
+        db_column='stellar_seed',
+        max_length=200,
+        blank=True,
+        null=True
+    )
+
+    @property
+    def stellar_seed(self) -> str | None:
+        """Decrypt and return the stellar seed."""
+        return decrypt_seed(self._stellar_seed)
+
+    @stellar_seed.setter
+    def stellar_seed(self, value: str | None):
+        """Encrypt the stellar seed before storing."""
+        self._stellar_seed = encrypt_seed(value) if value else value
+
+    class Meta:
+        # Ensures Django doesn't complain about the renamed field
+        pass
+
 
 class Course(models.Model):
     name = models.CharField(max_length=200)

--- a/attendance_system/settings.py
+++ b/attendance_system/settings.py
@@ -30,6 +30,7 @@ env = environ.Env(
     STELLAR_CONTRACT_ID=(str, ''),
     STELLAR_ADMIN_SECRET=(str, ''),
     STATIC_URL=(str, '/static/'),
+    STELLAR_SEED_ENCRYPTION_KEY=(str, ''),  # ← ADDED
 )
 
 # Read .env file if it exists (avoid hard coupling)
@@ -161,11 +162,6 @@ LOGOUT_REDIRECT_URL = 'home'
 # Crispy Forms
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
-# Stellar blockchain settings
-STELLAR_TESTNET = True
-STELLAR_HORIZON_URL = "https://horizon-testnet.stellar.org" if STELLAR_TESTNET else "https://horizon.stellar.org"
-STELLAR_RPC_URL = "https://soroban-testnet.stellar.org" if STELLAR_TESTNET else "https://soroban.stellar.org"
-
 # Email Configuration
 # Use environment variables for production, development backend for testing
 EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
@@ -198,9 +194,12 @@ CACHES = {
         'LOCATION': 'unique-snowflake',
     }
 }
+
+# Stellar blockchain settings
 STELLAR_NETWORK = env('STELLAR_NETWORK')
 STELLAR_TESTNET = STELLAR_NETWORK == 'testnet'
 STELLAR_HORIZON_URL = env('STELLAR_HORIZON_URL')
 STELLAR_RPC_URL = env('STELLAR_RPC_URL')
 STELLAR_CONTRACT_ID = env('STELLAR_CONTRACT_ID')
 STELLAR_ADMIN_SECRET = env('STELLAR_ADMIN_SECRET')
+STELLAR_SEED_ENCRYPTION_KEY = env('STELLAR_SEED_ENCRYPTION_KEY')  # ← ADDED


### PR DESCRIPTION
Fixes #1

## Summary
Stellar secret seeds were stored as plaintext in the database. This PR encrypts them at rest using Fernet symmetric encryption from the `cryptography` library (already a project dependency).

## Changes
- `attendance/encryption.py` — new encryption utility with `encrypt_seed` and `decrypt_seed` functions
- `attendance/models.py` — `stellar_seed` converted to a Python property that auto-encrypts on write and auto-decrypts on read, with no changes required in views or stellar_helper
- `attendance/migrations/0003_encrypt_stellar_seed.py` — widens the column and encrypts all existing plaintext seeds
- `attendance_system/settings.py` — adds `STELLAR_SEED_ENCRYPTION_KEY` env var
- `STELLAR_KEY_MANAGEMENT.md` — key rotation documentation

## How it works
- Seeds are stored with an `enc:` prefix to distinguish encrypted values from legacy plaintext
- The encryption key is stored in `STELLAR_SEED_ENCRYPTION_KEY` environment variable, never in code
- Migration is idempotent — safe to run multiple times

## Testing
- Set `STELLAR_SEED_ENCRYPTION_KEY` in `.env`
- Run `python manage.py migrate`
- Verify via shell: `u._stellar_seed` shows `enc:...`, `u.stellar_seed` returns plaintext

## Acceptance Criteria
- [x] Private keys encrypted at rest
- [x] Encryption key stored securely via env var
- [x] Migration script for existing keys
- [x] Key rotation documentation